### PR TITLE
bg: fix wrong namespace in requests

### DIFF
--- a/app/Http/Requests/API/CreateAccidentAPIRequest.php
+++ b/app/Http/Requests/API/CreateAccidentAPIRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Accident;
-use InfyOm\Generator\Request\APIRequest;
 
 class CreateAccidentAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateBreakdownAPIRequest.php
+++ b/app/Http/Requests/API/CreateBreakdownAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Breakdown;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateBreakdownAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateCountryAPIRequest.php
+++ b/app/Http/Requests/API/CreateCountryAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Country;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateCountryAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateFailedJobAPIRequest.php
+++ b/app/Http/Requests/API/CreateFailedJobAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\FailedJob;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateFailedJobAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateHospitalAPIRequest.php
+++ b/app/Http/Requests/API/CreateHospitalAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Hospital;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateHospitalAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateHospitalNotificationAPIRequest.php
+++ b/app/Http/Requests/API/CreateHospitalNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\HospitalNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateHospitalNotificationAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateHospitalResponseAPIRequest.php
+++ b/app/Http/Requests/API/CreateHospitalResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\HospitalResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateHospitalResponseAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateIncidentAPIRequest.php
+++ b/app/Http/Requests/API/CreateIncidentAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Incident;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateIncidentAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateKidnappingAPIRequest.php
+++ b/app/Http/Requests/API/CreateKidnappingAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Kidnapping;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateKidnappingAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateLgaAPIRequest.php
+++ b/app/Http/Requests/API/CreateLgaAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Lga;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateLgaAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreatePanicAPIRequest.php
+++ b/app/Http/Requests/API/CreatePanicAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Panic;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreatePanicAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreatePhoneAPIRequest.php
+++ b/app/Http/Requests/API/CreatePhoneAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Phone;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreatePhoneAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreatePickupAPIRequest.php
+++ b/app/Http/Requests/API/CreatePickupAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Pickup;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreatePickupAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreatePickupResponseAPIRequest.php
+++ b/app/Http/Requests/API/CreatePickupResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PickupResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreatePickupResponseAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreatePoliceResponseAPIRequest.php
+++ b/app/Http/Requests/API/CreatePoliceResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PoliceResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreatePoliceResponseAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreatePoliceStationAPIRequest.php
+++ b/app/Http/Requests/API/CreatePoliceStationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PoliceStation;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreatePoliceStationAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreatePoliceStationNotificationAPIRequest.php
+++ b/app/Http/Requests/API/CreatePoliceStationNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PoliceStationNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreatePoliceStationNotificationAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateResponseAPIRequest.php
+++ b/app/Http/Requests/API/CreateResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Response;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateResponseAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateRoadAPIRequest.php
+++ b/app/Http/Requests/API/CreateRoadAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Road;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateRoadAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateRoadSafetyResponseAPIRequest.php
+++ b/app/Http/Requests/API/CreateRoadSafetyResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\RoadSafetyResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateRoadSafetyResponseAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateRobberyAPIRequest.php
+++ b/app/Http/Requests/API/CreateRobberyAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Robbery;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateRobberyAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateSafetyForceAPIRequest.php
+++ b/app/Http/Requests/API/CreateSafetyForceAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\SafetyForce;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateSafetyForceAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateStateAPIRequest.php
+++ b/app/Http/Requests/API/CreateStateAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\State;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateStateAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateTowResponseAPIRequest.php
+++ b/app/Http/Requests/API/CreateTowResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\TowResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateTowResponseAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateTowerAPIRequest.php
+++ b/app/Http/Requests/API/CreateTowerAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Tower;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateTowerAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateTowerNotificationAPIRequest.php
+++ b/app/Http/Requests/API/CreateTowerNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\TowerNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateTowerNotificationAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateTripAPIRequest.php
+++ b/app/Http/Requests/API/CreateTripAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Trip;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateTripAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateUserAPIRequest.php
+++ b/app/Http/Requests/API/CreateUserAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\User;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateUserAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateUserNotificationAPIRequest.php
+++ b/app/Http/Requests/API/CreateUserNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\UserNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateUserNotificationAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/CreateUserSettingAPIRequest.php
+++ b/app/Http/Requests/API/CreateUserSettingAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\UserSetting;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class CreateUserSettingAPIRequest extends APIRequest
 {

--- a/app/Http/Requests/API/UpdateAccidentAPIRequest.php
+++ b/app/Http/Requests/API/UpdateAccidentAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Accident;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateAccidentAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateAccidentAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Accident::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateBreakdownAPIRequest.php
+++ b/app/Http/Requests/API/UpdateBreakdownAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Breakdown;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateBreakdownAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateBreakdownAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Breakdown::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateCountryAPIRequest.php
+++ b/app/Http/Requests/API/UpdateCountryAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Country;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateCountryAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateCountryAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Country::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateFailedJobAPIRequest.php
+++ b/app/Http/Requests/API/UpdateFailedJobAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\FailedJob;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateFailedJobAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateFailedJobAPIRequest extends APIRequest
     public function rules()
     {
         $rules = FailedJob::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateHospitalAPIRequest.php
+++ b/app/Http/Requests/API/UpdateHospitalAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Hospital;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateHospitalAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateHospitalAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Hospital::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateHospitalNotificationAPIRequest.php
+++ b/app/Http/Requests/API/UpdateHospitalNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\HospitalNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateHospitalNotificationAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateHospitalNotificationAPIRequest extends APIRequest
     public function rules()
     {
         $rules = HospitalNotification::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateHospitalResponseAPIRequest.php
+++ b/app/Http/Requests/API/UpdateHospitalResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\HospitalResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateHospitalResponseAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateHospitalResponseAPIRequest extends APIRequest
     public function rules()
     {
         $rules = HospitalResponse::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateIncidentAPIRequest.php
+++ b/app/Http/Requests/API/UpdateIncidentAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Incident;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateIncidentAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateIncidentAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Incident::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateKidnappingAPIRequest.php
+++ b/app/Http/Requests/API/UpdateKidnappingAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Kidnapping;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateKidnappingAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateKidnappingAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Kidnapping::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateLgaAPIRequest.php
+++ b/app/Http/Requests/API/UpdateLgaAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Lga;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateLgaAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateLgaAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Lga::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdatePanicAPIRequest.php
+++ b/app/Http/Requests/API/UpdatePanicAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Panic;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdatePanicAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdatePanicAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Panic::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdatePhoneAPIRequest.php
+++ b/app/Http/Requests/API/UpdatePhoneAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Phone;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdatePhoneAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdatePhoneAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Phone::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdatePickupAPIRequest.php
+++ b/app/Http/Requests/API/UpdatePickupAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Pickup;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdatePickupAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdatePickupAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Pickup::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdatePickupResponseAPIRequest.php
+++ b/app/Http/Requests/API/UpdatePickupResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PickupResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdatePickupResponseAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdatePickupResponseAPIRequest extends APIRequest
     public function rules()
     {
         $rules = PickupResponse::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdatePoliceResponseAPIRequest.php
+++ b/app/Http/Requests/API/UpdatePoliceResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PoliceResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdatePoliceResponseAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdatePoliceResponseAPIRequest extends APIRequest
     public function rules()
     {
         $rules = PoliceResponse::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdatePoliceStationAPIRequest.php
+++ b/app/Http/Requests/API/UpdatePoliceStationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PoliceStation;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdatePoliceStationAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdatePoliceStationAPIRequest extends APIRequest
     public function rules()
     {
         $rules = PoliceStation::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdatePoliceStationNotificationAPIRequest.php
+++ b/app/Http/Requests/API/UpdatePoliceStationNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\PoliceStationNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdatePoliceStationNotificationAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdatePoliceStationNotificationAPIRequest extends APIRequest
     public function rules()
     {
         $rules = PoliceStationNotification::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateResponseAPIRequest.php
+++ b/app/Http/Requests/API/UpdateResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Response;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateResponseAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateResponseAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Response::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateRoadAPIRequest.php
+++ b/app/Http/Requests/API/UpdateRoadAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Road;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateRoadAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateRoadAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Road::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateRoadSafetyResponseAPIRequest.php
+++ b/app/Http/Requests/API/UpdateRoadSafetyResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\RoadSafetyResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateRoadSafetyResponseAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateRoadSafetyResponseAPIRequest extends APIRequest
     public function rules()
     {
         $rules = RoadSafetyResponse::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateRobberyAPIRequest.php
+++ b/app/Http/Requests/API/UpdateRobberyAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Robbery;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateRobberyAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateRobberyAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Robbery::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateSafetyForceAPIRequest.php
+++ b/app/Http/Requests/API/UpdateSafetyForceAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\SafetyForce;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateSafetyForceAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateSafetyForceAPIRequest extends APIRequest
     public function rules()
     {
         $rules = SafetyForce::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateStateAPIRequest.php
+++ b/app/Http/Requests/API/UpdateStateAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\State;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateStateAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateStateAPIRequest extends APIRequest
     public function rules()
     {
         $rules = State::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateTowResponseAPIRequest.php
+++ b/app/Http/Requests/API/UpdateTowResponseAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\TowResponse;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateTowResponseAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateTowResponseAPIRequest extends APIRequest
     public function rules()
     {
         $rules = TowResponse::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateTowerAPIRequest.php
+++ b/app/Http/Requests/API/UpdateTowerAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Tower;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateTowerAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateTowerAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Tower::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateTowerNotificationAPIRequest.php
+++ b/app/Http/Requests/API/UpdateTowerNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\TowerNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateTowerNotificationAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateTowerNotificationAPIRequest extends APIRequest
     public function rules()
     {
         $rules = TowerNotification::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateTripAPIRequest.php
+++ b/app/Http/Requests/API/UpdateTripAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Trip;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateTripAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateTripAPIRequest extends APIRequest
     public function rules()
     {
         $rules = Trip::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateUserAPIRequest.php
+++ b/app/Http/Requests/API/UpdateUserAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\User;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateUserAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateUserAPIRequest extends APIRequest
     public function rules()
     {
         $rules = User::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateUserNotificationAPIRequest.php
+++ b/app/Http/Requests/API/UpdateUserNotificationAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\UserNotification;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateUserNotificationAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateUserNotificationAPIRequest extends APIRequest
     public function rules()
     {
         $rules = UserNotification::$rules;
-        
+
         return $rules;
     }
 }

--- a/app/Http/Requests/API/UpdateUserSettingAPIRequest.php
+++ b/app/Http/Requests/API/UpdateUserSettingAPIRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 use App\Models\UserSetting;
-use InfyOm\Generator\Request\APIRequest;
+
 
 class UpdateUserSettingAPIRequest extends APIRequest
 {
@@ -25,7 +25,7 @@ class UpdateUserSettingAPIRequest extends APIRequest
     public function rules()
     {
         $rules = UserSetting::$rules;
-        
+
         return $rules;
     }
 }


### PR DESCRIPTION
Fix wrong namespace in used in app\Http\Requests classes

Fixes: #45